### PR TITLE
Upgrade Phusion baseimage to newest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:0.9.19
+FROM phusion/baseimage:0.11
 
 # Basic install of apache
 RUN \


### PR DESCRIPTION
Vores gamle build er efterhånden to år gammelt ...

Jeg har sat Docker Hub til også at builde tags fremadrettet og så tænker jeg at tagge en release når denne er merget.