### PR TITLE
Adapt the build workflow job and step names depending on trigger branch

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,10 +1,10 @@
 on: push
 
-name: Docker build and push
-jobs:
+name: Build. Publish on merge
 
+jobs:
   build:
-    name: Docker build and push
+    name: Docker build${{ (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && ' and push') || '' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,7 +24,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
-    - name: Build and push Docker images
+    - name: Build${{ (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && ' and push') || '' }} Docker images
       uses: docker/build-push-action@v3
       with:
         file: Dockerfile


### PR DESCRIPTION
We want to make it clear when the workflow pushes the build it produces.

This PR adds a bit of interpolation to the workflow to achive this.
