### PR TITLE
Enable the mod_headers module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   a2enmod remoteip && \
   a2enmod expires && \
   a2enmod ssl && \
+  a2enmod headers && \
   a2ensite ssl && \
   a2enconf allow-override-all && \
   a2enconf php-fpm


### PR DESCRIPTION
This change makes it possible to add CORS and other headers to HTTP responses.

This is necessary if we want to use static assets like fonts and icons in single directory components rendered in Storybook using the new Storybook contrib module.

Add the following directives to the `.htaccess`-file in your web root to set the required header:

```
<FilesMatch "\.(eot|gif|ico|jpeg|jpg|otf|png|svg|ttf|woff|woff2)$">
  <IfModule mod_headers.c>
    Header set Access-Control-Allow-Origin "*"
  </IfModule>
</FilesMatch>
```