### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @reload/developers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,16 @@
 version: 2
 updates:
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '04:00'
-    timezone: Europe/Copenhagen
-  open-pull-requests-limit: 10
-  reviewers:
-  - "reload/developers"
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: daily
-    time: '04:00'
-    timezone: Europe/Copenhagen
-  open-pull-requests-limit: 10
-  reviewers:
-  - "reload/developers"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '04:00'
+      timezone: Europe/Copenhagen
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+      time: '04:00'
+      timezone: Europe/Copenhagen
+    open-pull-requests-limit: 10


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
